### PR TITLE
keep pytest-cmd-flags in debug mode, fix pytest-pdb-one call

### DIFF
--- a/pytest.el
+++ b/pytest.el
@@ -117,7 +117,7 @@ Optional argument FLAGS py.test command line flags."
 (defun pytest-pdb-all ()
   "Start pdb on error."
   (interactive)
-  (pytest-all "--pdb -x"))
+  (pytest-all (concat "--pdb " pytest-cmd-flags)))
 
 ;;; Run all the tests in a directory (and its child directories)
 (defun pytest-directory (&optional flags)
@@ -130,7 +130,7 @@ Optional argument FLAGS py.test command line flags."
   "Run pytest on all the files in the current buffer.
 Optional argument FLAGS py.test command line flags."
   (interactive)
-  (pytest-directory "--pdb -x "))
+  (pytest-directory (concat "--pdb " pytest-cmd-flags)))
 
 ;;; Run all the tests in a file
 (defun pytest-module (&optional flags)
@@ -142,19 +142,19 @@ Optional argument FLAGS py.test command line flags."
 (defun pytest-pdb-module ()
   "Run pytest on a module, enter debugger on error."
   (interactive)
-  (pytest-module "--pdb -x"))
+  (pytest-module (concat "--pdb " pytest-cmd-flags)))
 
 ;;; Run the test surrounding the current point
 (defun pytest-one (&optional flags)
   "Run pytest (via eggs/bin/test) on testable thing at point in current buffer.
 Optional argument FLAGS py.test command line flags."
   (interactive)
-  (pytest-run (format (concat flags "%s") (pytest-py-testable))))
+  (pytest-run (format "%s" (pytest-py-testable)) flags))
 
 (defun pytest-pdb-one ()
   "Run pytest on testable thing at point, enter debugger on error."
   (interactive)
-  (pytest-one "-x "))
+  (pytest-one (concat "--pdb " pytest-cmd-flags)))
 
 
 ;;; Utility functions


### PR DESCRIPTION
This keeps the pytest-cmd-flags that a user might have set also in debug `pdb` mode.

It also fixes the call for `pytest-pdb-one`
