### PR TITLE
Add defgroup for customize and suppressing byte-compile warnings

### DIFF
--- a/pytest.el
+++ b/pytest.el
@@ -67,6 +67,10 @@
 (require 'cl)
 (require 'python)
 
+(defgroup pytest nil
+  "Easy Python test running in Emacs"
+  :group 'python)
+
 (defcustom pytest-project-names '("runtests")
   "The name of the script that starts the tests.")
 


### PR DESCRIPTION
There are some warnings about this.

```
pytest.el:70:1:Warning: defcustom for `pytest-project-names' fails to specify                                                                                  
    containing group                                                                                                                                           
pytest.el:70:1:Warning: defcustom for `pytest-project-names' fails to specify                                                                                  
    containing group                                                                                                                                           
pytest.el:73:1:Warning: defcustom for `pytest-project-root-files' fails to                                                                                     
    specify containing group                                                                                                                                   
pytest.el:73:1:Warning: defcustom for `pytest-project-root-files' fails to                                                                                     
    specify containing group                                                                                                                                   
pytest.el:76:1:Warning: defcustom for `pytest-project-root-test' fails to                                                                                      
    specify containing group                                                                                                                                   
pytest.el:76:1:Warning: defcustom for `pytest-project-root-test' fails to                                                                                      
    specify containing group                                                                                                                                   
pytest.el:79:1:Warning: defcustom for `pytest-global-name' fails to specify                                                                                    
    containing group                                                                                                                                           
pytest.el:79:1:Warning: defcustom for `pytest-global-name' fails to specify                                                                                    
    containing group                                                                                                                                           
pytest.el:83:1:Warning: defcustom for `pytest-cmd-flags' fails to specify                                                                                      
    containing group                                                                                                                                           
pytest.el:83:1:Warning: defcustom for `pytest-cmd-flags' fails to specify                                                                                      
    containing group  
```
