### PR TITLE
Allow a test buffer per project if projectile is installed.

### DIFF
--- a/pytest.el
+++ b/pytest.el
@@ -127,11 +127,21 @@ Optional argument FLAGS py.test command line flags."
          (use-comint (s-contains? "pdb" cmd-flags)))
     (funcall #'(lambda (command)
                  (compilation-start command use-comint
-                                    (lambda (mode) (concat "*pytest*"))))
+                                    (lambda (mode) (concat (pytest-get-temp-buffer-name)))))
              (pytest-cmd-format pytest-cmd-format-string where pytest cmd-flags tnames))
     (if use-comint
-	(with-current-buffer (get-buffer "*pytest*")
+	(with-current-buffer (get-buffer (pytest-get-temp-buffer-name))
 	  (inferior-python-mode)))))
+
+(defun pytest-get-temp-buffer-name ()
+  "Get name of temporary buffer.
+Includes projectile support if installed.
+This allows one test buffer per project."
+  (let ((postfix (if (and (fboundp 'projectile-project-p)
+                          (projectile-project-p))
+                     (concat "-" (projectile-project-name) "*")
+                   "*")))
+    (concat "*pytest" postfix)))
 
 ;;; Run entire test suite
 ;;;###autoload


### PR DESCRIPTION
This makes is possible to work on multiple projects at the same time
without having to close the other test buffers which might still contain
useful information.