### PR TITLE
Add pytest-source-root-dir variable

### DIFF
--- a/README.org
+++ b/README.org
@@ -57,6 +57,34 @@ whether a directory is the project root:
   (setq pytest-project-root-test (lambda (dirname) (equal dirname "foo")))
 #+END_SRC
 
+By default, test paths passed to pytest are absolute paths:
+#+BEGIN_SRC sh
+  cd /project/root && pytest /base/path/relative/path/to/test.py
+#+END_SRC
+
+To override this behavior, set an optional source root directory:
+#+BEGIN_SRC elisp
+  (setq pytest-source-root-dir "/base/path/")
+#+END_SRC
+
+which will set test paths relative to that source root:
+#+BEGIN_SRC sh
+   cd /project/root && pytest relative/path/to/test.py
+#+END_SRC
+
+This will enable individual tests to run correctly in containers that map to different working directories:
+#+BEGIN_SRC elisp
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((python-mode
+  (pytest-global-name . "docker-compose run --rm app pytest")
+  (pytest-cmd-flags . "")
+  (pytest-source-root-dir . "/base/path/")))
+#+END_SRC
+
+
+
 ** Key bindings
 
 Here are some suggested keybindings for running the tests within your

--- a/README.org
+++ b/README.org
@@ -59,31 +59,51 @@ whether a directory is the project root:
 
 By default, test paths passed to pytest are absolute paths:
 #+BEGIN_SRC sh
-  cd /project/root && pytest /base/path/relative/path/to/test.py
+  cd /project/root && pytest /project/root/path/to/test.py
 #+END_SRC
 
-To override this behavior, set an optional source root directory:
+To override this behavior, set an optional base path that will be stripped from test path arguments:
 #+BEGIN_SRC elisp
-  (setq pytest-source-root-dir "/base/path/")
+  (setq pytest-relative-test-paths "/project/root/")
 #+END_SRC
 
-which will set test paths relative to that source root:
+which will set test paths relative to that base path:
 #+BEGIN_SRC sh
-   cd /project/root && pytest relative/path/to/test.py
+   cd /project/root && pytest path/to/test.py
 #+END_SRC
 
 This will enable individual tests to run correctly in containers that map to different working directories:
 #+BEGIN_SRC elisp
+;;; Example dir-locals.el:
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 
 ((python-mode
   (pytest-global-name . "docker-compose run --rm app pytest")
   (pytest-cmd-flags . "")
-  (pytest-source-root-dir . "/base/path/")))
+  (pytest-relative-test-paths . "/base/path/")))
 #+END_SRC
 
+An example of why you'd want to apply relative test path arguments is running tests in a docker compose environment for an app that contains multiple sub-projects and those tests are contained within a mounted volume that is a subdirectory of the project root:
+#+BEGIN_SRC shell
+  # project root
+  /project/root/
+  # local app directory
+  /project/root/app
+  # corresponding container app directory mounted in container
+  /opt/app
+  # default full test path outside of container
+  /project/root/app/path/to/test.py
+#+END_SRC
+In that case, running the default command in the container will fail since it does not take into account the container directory structure:
+#+BEGIN_SRC sh
+    cd /path/to/project/root && docker-compose run --rm app pytest /path/to/docker/mount/volume/relative/path/to/test.py
+#+END_SRC
 
+but passing in a relative test path should run:
+#+BEGIN_SRC sh
+  cd /path/to/project/root && docker-compose run --rm app pytest relative/path/to/test.py
+#+END_SRC
 
 ** Key bindings
 

--- a/pytest.el
+++ b/pytest.el
@@ -52,10 +52,10 @@
 ;; ; (setq pytest-project-root-test (lambda (dirname) (equal dirname "foo")))
 
 ;; By default, test paths passed to pytest are absolute paths:
-;; 'cd /project/root && pytest /base/path/relative/path/to/test.py'
-;; Set an optional source root directory:
-;; ; (setq pytest-source-root-dir "/base/path/")
-;; which will set test paths relative to that source root:
+;; 'cd /project/root && pytest /project/root/path/to/test.py'
+;; To override this behavior, set an optional base path that will be stripped from test path arguments:
+;; ; (setq pytest-relative-test-paths "/project/root/")
+;; which will set test paths relative to that base path:
 ;; 'cd /project/root && pytest relative/path/to/test.py'
 
 ;; Probably also want some keybindings:
@@ -97,7 +97,7 @@
 (defcustom pytest-cmd-format-string "cd '%s' && %s %s '%s'"
   "Format string used to run the py.test command.")
 
-(defcustom pytest-source-root-dir nil
+(defcustom pytest-relative-test-paths nil
   "If set, test paths will be defined relative to this base directory.")
 
 (defvar pytest-last-commands (make-hash-table :test 'equal)
@@ -140,8 +140,8 @@ Optional argument FLAGS py.test command line flags."
                       ((stringp tests) (split-string tests))))
          (tnames
           (mapconcat
-           (if pytest-source-root-dir
-               (lambda (x) (file-relative-name x pytest-source-root-dir))
+           (if pytest-relative-test-paths
+               (lambda (x) (file-relative-name x pytest-relative-test-paths))
              (apply-partially 'format "'%s'"))
            tests " "))
          (cmd-flags (if flags flags pytest-cmd-flags)))

--- a/pytest.el
+++ b/pytest.el
@@ -135,7 +135,7 @@ Optional argument FLAGS py.test command line flags."
                     (let ((testpath (if (listp tests) (car tests) tests)))
                       (pytest-find-project-root (file-name-directory testpath)))
                   (pytest-find-project-root)))
-         (tests (cond ((not tests) (list "."))
+         (tests (cond ((not tests) nil)
                       ((listp tests) tests)
                       ((stringp tests) (split-string tests))))
          (tnames

--- a/pytest.el
+++ b/pytest.el
@@ -4,7 +4,7 @@
 
 ;; Licensed under the same terms as Emacs.
 
-;; Version: 0.2.1
+;; Version: 0.3.0
 ;; Keywords: pytest python testing
 ;; URL: https://github.com/ionrock/pytest-el
 ;; Package-Requires: ((s "1.9.0"))

--- a/pytest.el
+++ b/pytest.el
@@ -51,6 +51,13 @@
 ;;
 ;; ; (setq pytest-project-root-test (lambda (dirname) (equal dirname "foo")))
 
+;; By default, test paths passed to pytest are absolute paths:
+;; 'cd /project/root && pytest /base/path/relative/path/to/test.py'
+;; Set an optional source root directory:
+;; ; (setq pytest-source-root-dir "/base/path/")
+;; which will set test paths relative to that source root:
+;; 'cd /project/root && pytest relative/path/to/test.py'
+
 ;; Probably also want some keybindings:
 ;; (add-hook 'python-mode-hook
 ;;           (lambda ()
@@ -90,6 +97,9 @@
 (defcustom pytest-cmd-format-string "cd '%s' && %s %s '%s'"
   "Format string used to run the py.test command.")
 
+(defcustom pytest-source-root-dir ""
+  "If set, test paths will be defined relative to this base directory.")
+
 (defvar pytest-last-commands (make-hash-table :test 'equal)
   "Last pytest commands by pytest buffer name")
 
@@ -128,7 +138,7 @@ Optional argument FLAGS py.test command line flags."
          (tests (cond ((not tests) (list "."))
                       ((listp tests) tests)
                       ((stringp tests) (split-string tests))))
-         (tnames (mapconcat (apply-partially 'format "'%s'") tests " "))
+         (tnames (mapconcat (lambda (x) (file-relative-name x pytest-source-root-dir)) tests " "))
          (cmd-flags (if flags flags pytest-cmd-flags)))
     (pytest-cmd-format pytest-cmd-format-string where pytest cmd-flags tnames)))
 

--- a/pytest.el
+++ b/pytest.el
@@ -97,7 +97,7 @@
 (defcustom pytest-cmd-format-string "cd '%s' && %s %s '%s'"
   "Format string used to run the py.test command.")
 
-(defcustom pytest-source-root-dir ""
+(defcustom pytest-source-root-dir nil
   "If set, test paths will be defined relative to this base directory.")
 
 (defvar pytest-last-commands (make-hash-table :test 'equal)
@@ -138,7 +138,12 @@ Optional argument FLAGS py.test command line flags."
          (tests (cond ((not tests) (list "."))
                       ((listp tests) tests)
                       ((stringp tests) (split-string tests))))
-         (tnames (mapconcat (lambda (x) (file-relative-name x pytest-source-root-dir)) tests " "))
+         (tnames
+          (mapconcat
+           (if pytest-source-root-dir
+               (lambda (x) (file-relative-name x pytest-source-root-dir))
+             (apply-partially 'format "'%s'"))
+           tests " "))
          (cmd-flags (if flags flags pytest-cmd-flags)))
     (pytest-cmd-format pytest-cmd-format-string where pytest cmd-flags tnames)))
 


### PR DESCRIPTION
For #35.

Adds a `pytest-source-root-dir` variable that defaults to `nil`. When this variable is set, the test paths passed to pytest will be relative to the directory defined by that variable.